### PR TITLE
namespace under napa instead of naparails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+master
+===
+
+0.1.0
+===
+* Add grape_extensions folder with error_formatter and grape_helpers
+* Add output_formatters folder with include_nil, pagination, representer
+* Add rspec_extensions with response_helpers
+* Add json_error
+* Add kaminari, grape and roar dependency

--- a/lib/napa.rb
+++ b/lib/napa.rb
@@ -10,6 +10,4 @@ require "napa/grape_extensions/error_formatter"
 require "napa/json_error"
 
 module Napa
-
-  # Your code goes here...
 end

--- a/lib/napa.rb
+++ b/lib/napa.rb
@@ -1,0 +1,15 @@
+require "grape"
+require "kaminari"
+require "napa/version"
+require "napa/rspec_extensions/response_helpers"
+require "napa/output_formatters/include_nil"
+require "napa/output_formatters/representer"
+require "napa/output_formatters/pagination"
+require "napa/grape_extensions/grape_helpers"
+require "napa/grape_extensions/error_formatter"
+require "napa/json_error"
+
+module Napa
+
+  # Your code goes here...
+end

--- a/lib/napa/grape_extensions/error_formatter.rb
+++ b/lib/napa/grape_extensions/error_formatter.rb
@@ -1,0 +1,18 @@
+if defined?(Grape)
+  module Grape
+    module ErrorFormatter
+      module Json
+        class << self
+          def call(message, backtrace, options = {}, _env = nil)
+            result = message.is_a?(Napa::JsonError) ? message : Napa::JsonError.new(:api_error, message)
+
+            if (options[:rescue_options] || {})[:backtrace] && backtrace && !backtrace.empty?
+              result = result.to_h.merge(backtrace: backtrace)
+            end
+            MultiJson.dump(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/napa/grape_extensions/grape_helpers.rb
+++ b/lib/napa/grape_extensions/grape_helpers.rb
@@ -1,0 +1,65 @@
+module Napa
+  module GrapeHelpers
+    def represent(data, with: nil, **args)
+      fail ArgumentError, ':with option is required' if with.nil?
+
+      if data.respond_to?(:map)
+        return { data: data.map { |item| with.new(item).to_hash(args) } }
+      else
+        return { data: with.new(data).to_hash(args) }
+      end
+    end
+
+    def present_error(code, message = '', reasons = {})
+      Napa::JsonError.new(code, message, reasons)
+    end
+
+    def permitted_params(options = {})
+      options = { include_missing: false }.merge(options)
+      declared(params, options)
+    end
+
+    def paginate(data, with: nil, **args)
+      raise ArgumentError.new(":with option is required") if with.nil?
+
+      if data.respond_to?(:to_a)
+        return {}.tap do |r|
+          data = Napa::Pagination.new(represent_pagination(data))
+          r[:data] = data.map{ |item| with.new(item).to_hash(args) }
+          r[:pagination] = data.to_h
+        end
+      else
+        return { data: with.new(data).to_hash(args) }
+      end
+    end
+
+    def represent_pagination(data)
+      # don't paginate if collection is already paginated
+      return data if data.respond_to?(:total_count)
+
+      page      = params.try(:page) || 1
+      per_page  = params.try(:per_page) || 25
+
+      order_by_params!(data) if data.is_a?(ActiveRecord::Relation) && data.size > 0
+
+      if data.is_a?(Array)
+        Kaminari.paginate_array(data).page(page).per(per_page)
+      else
+        data.page(page).per(per_page)
+      end
+    end
+
+    def order_by_params!(data)
+      if params[:sort_by] && data.column_names.map(&:to_sym).include?(params[:sort_by].to_sym)
+        sort_order = params[:sort_order] || :asc
+        data.order!(params[:sort_by] => sort_order.to_sym)
+      end
+      data
+    end
+
+    # extend all endpoints to include this
+    Grape::Endpoint.send :include, self if defined?(Grape)
+    # rails 4 controller concern
+    extend ActiveSupport::Concern if defined?(Rails)
+  end
+end

--- a/lib/napa/json_error.rb
+++ b/lib/napa/json_error.rb
@@ -1,0 +1,24 @@
+module Napa
+  class JsonError
+    def initialize(code, message, reasons = {})
+      @code = code
+      @message = message
+      @reasons = reasons
+    end
+
+    def to_json(options = {})
+      to_h.to_json(options)
+    end
+
+    def to_h
+      e = {
+        error: {
+          code: @code,
+          message: @message
+        }
+      }
+      e[:error][:reasons] = @reasons if @reasons.present?
+      e
+    end
+  end
+end

--- a/lib/napa/output_formatters/include_nil.rb
+++ b/lib/napa/output_formatters/include_nil.rb
@@ -1,0 +1,16 @@
+# include this in your representer, and you will always return all defined keys (even if their value is nil)
+module Napa
+  module Representable
+    module IncludeNil
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        def property(name, options = {}, &block)
+          super(name, options.merge(render_nil: true), &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/napa/output_formatters/pagination.rb
+++ b/lib/napa/output_formatters/pagination.rb
@@ -1,0 +1,27 @@
+module Napa
+  class Pagination
+    include Enumerable
+    def initialize(object)
+      @object = object
+    end
+
+    def to_json(options = {})
+      to_h.to_json(options)
+    end
+
+    def to_h
+      {}.tap do |p|
+        p[:page]          = @object.current_page  if @object.respond_to?(:current_page)
+        p[:per_page]      = @object.limit_value   if @object.respond_to?(:limit_value)
+        p[:total_pages]   = @object.total_pages   if @object.respond_to?(:total_pages)
+        p[:total_count]   = @object.total_count   if @object.respond_to?(:total_count)
+      end
+    end
+
+    def each(&block)
+      @object.each do |member|
+        block.call(member)
+      end
+    end
+  end
+end

--- a/lib/napa/output_formatters/representer.rb
+++ b/lib/napa/output_formatters/representer.rb
@@ -1,0 +1,24 @@
+require 'roar/decorator'
+require 'roar/version'
+
+if Roar::VERSION >= '1.0.0'
+  require 'roar/json'
+  require 'roar/coercion'
+else
+  require 'roar/representer/json'
+  require 'roar/representer/feature/coercion'
+end
+
+module Napa
+  class Representer < Roar::Decorator
+    include Coercion
+
+    if Roar::VERSION >= '1.0.0'
+      include Roar::JSON
+    else
+      include Roar::Representer::JSON
+    end
+
+    property :object_type, getter: ->(*) { self.class.name.underscore }
+  end
+end

--- a/lib/napa/rspec_extensions/response_helpers.rb
+++ b/lib/napa/rspec_extensions/response_helpers.rb
@@ -1,0 +1,50 @@
+module Napa
+  module RspecExtensions
+    module ResponseHelpers
+      def parsed_response
+        Hashie::Mash.new(JSON.parse(last_response.body))
+      end
+
+      def response_code
+        last_response.status
+      end
+
+      def response_body
+        last_response.body
+      end
+
+      def result_count
+        parsed_response.data.count
+      end
+
+      def first_result
+        parsed_response.data.first
+      end
+
+      def result_with_id(id)
+        parsed_response.data.select { |r| r.id == id }.first
+      end
+
+      def expect_count_of(count)
+        expect(result_count).to eq(count)
+      end
+
+      def expect_error_code(error_code)
+        expect(parsed_response.error.code).to eq(error_code.to_s)
+      end
+
+      def expect_only(object)
+        expect_count_of 1
+        expect(first_result.id).to eq(object.id)
+      end
+
+      def expect_to_have(object)
+        expect(!result_with_id(object.id).nil?).to be_truthy
+      end
+
+      def expect_to_not_have(object)
+        expect(!result_with_id(object.id).nil?).to be_falsy
+      end
+    end
+  end
+end

--- a/lib/napa/version.rb
+++ b/lib/napa/version.rb
@@ -1,3 +1,3 @@
-module NapaRails
+module Napa
   VERSION = "0.1.0"
 end

--- a/lib/napa_rails.rb
+++ b/lib/napa_rails.rb
@@ -1,5 +1,0 @@
-require "napa_rails/version"
-
-module NapaRails
-  # Your code goes here...
-end

--- a/napa_rails.gemspec
+++ b/napa_rails.gemspec
@@ -1,17 +1,17 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'napa_rails/version'
+require 'napa/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "napa_rails"
-  spec.version       = NapaRails::VERSION
-  spec.authors       = ["TODO: Write your name"]
-  spec.email         = ["TODO: Write your email address"]
+  spec.version       = Napa::VERSION
+  spec.authors       = ["Darby Frey, Flori Garcia"]
+  spec.email         = ["darby@bellycard.com, flori@bellycard.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = %q{Napa features for Rails}
+  spec.description   = %q{Napa features for Rails}
+  spec.homepage      = "https://github.com/bellycard/napa_rails"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.add_dependency "grape"
+  spec.add_dependency "kaminari"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/napa_rails.gemspec
+++ b/napa_rails.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.add_dependency "grape"
   spec.add_dependency "kaminari"
+  spec.add_dependency 'roar', ['>= 0.12.0', '< 2.0']
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/grape_extensions/error_formatter_spec.rb
+++ b/spec/grape_extensions/error_formatter_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'napa/grape_extensions/error_formatter'
+
+describe Grape::ErrorFormatter::Json do
+  context '#call' do
+    it 'returns an api_error for plain error messages' do
+      error = Grape::ErrorFormatter::Json.call('test message', nil)
+      parsed = JSON.parse(error)
+      expect(parsed['error']['code']).to eq('api_error')
+      expect(parsed['error']['message']).to eq('test message')
+    end
+
+    it 'returns a specified error when given a Napa::JsonError object' do
+      json_error = Napa::JsonError.new(:foo, 'bar')
+      error = Grape::ErrorFormatter::Json.call(json_error, nil)
+      parsed = JSON.parse(error)
+      expect(parsed['error']['code']).to eq('foo')
+      expect(parsed['error']['message']).to eq('bar')
+    end
+
+    it 'adds the backtrace with rescue_option[:backtrace] specified' do
+      error = Grape::ErrorFormatter::Json.call('',
+                                               'backtrace',
+                                               rescue_options: { backtrace: true })
+      parsed = JSON.parse(error)
+      expect(parsed['backtrace']).to eq('backtrace')
+    end
+  end
+end

--- a/spec/grape_extensions/grape_helpers_spec.rb
+++ b/spec/grape_extensions/grape_helpers_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'napa/grape_extensions/error_formatter'
+
+describe Napa::GrapeHelpers do
+  describe '#represent' do
+    it 'should not rely on to_a if the data is enumerable with :map' do
+      class Foo
+      end
+
+      class FooRepresenter < Napa::Representer
+      end
+
+      class DummyClass
+        include Napa::GrapeHelpers
+      end
+
+      foo = double('Foo')
+      expect(foo).not_to receive(:to_a)
+      expect(foo).to receive(:map) { %w('foo', 'bar') }
+
+      DummyClass.new.represent(foo, with: FooRepresenter)
+    end
+  end
+end

--- a/spec/napa_spec.rb
+++ b/spec/napa_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe NapaRails do
+describe Napa do
   it 'has a version number' do
-    expect(NapaRails::VERSION).not_to be nil
+    expect(Napa::VERSION).not_to be nil
   end
 
   it 'does something useful' do

--- a/spec/napa_spec.rb
+++ b/spec/napa_spec.rb
@@ -4,8 +4,4 @@ describe Napa do
   it 'has a version number' do
     expect(Napa::VERSION).not_to be nil
   end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
-  end
 end

--- a/spec/output_formatters/pagination_spec.rb
+++ b/spec/output_formatters/pagination_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+# require 'active_record'
+require 'hashie'
+require 'napa/output_formatters/pagination'
+
+describe Napa::Pagination do
+  context '#to_h' do
+    it 'returns all pagination attributes that the object responds to' do
+      object = Hashie::Mash.new(
+        current_page: 2,
+        limit_value: 25,
+        total_pages: 10,
+        total_count: 248
+      )
+
+      data = Napa::Pagination.new(object)
+      expect(data.to_h[:page]).to be(2)
+      expect(data.to_h[:per_page]).to be(25)
+      expect(data.to_h[:total_pages]).to be(10)
+      expect(data.to_h[:total_count]).to be(248)
+    end
+
+    it 'skips an attribute if the object does not respond to it' do
+      object = Hashie::Mash.new(
+        current_page: 2,
+        limit_value: 25
+      )
+
+      data = Napa::Pagination.new(object)
+      expect(data.to_h[:page]).to be(2)
+      expect(data.to_h[:per_page]).to be(25)
+      expect(data.to_h[:total_pages]).to be_nil
+      expect(data.to_h[:total_count]).to be_nil
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'napa_rails'
+require 'napa'


### PR DESCRIPTION
This has been created to be used first in the image-service-rails app. The way it stands now, we can pull out napa and add napa_rails to image-service-rails and all the test still pass.
@bellycard/platform 
@darbyfrey 
