### PR TITLE
Adding result_count for backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 master
+====
+
+0.1.5
 ===
+* Add `result_count` key to Pagination for backward compatibility
+
+0.1.4
+===
+* Add SortableApi
+* Add active_record dependency
+* Add acts_as_fu development dependency
+
+0.1.3
+===
+* Require napa/grape_extensions/grape_extenders
+
+0.1.2
+===
+* Require napa in napa_rails file
+
+0.1.1
+===
+* Require kaminari/grape
 
 0.1.0
 ===
@@ -8,21 +30,3 @@ master
 * Add rspec_extensions with response_helpers
 * Add json_error
 * Add kaminari, grape and roar dependency
-
-0.1.1
-===
-* Require kaminari/grape
-
-0.1.2
-===
-* Require napa in napa_rails file
-
-0.1.3
-===
-* Require napa/grape_extensions/grape_extenders
-
-0.1.4
-===
-* Add SortableApi
-* Add active_record dependency
-* Add acts_as_fu development dependency

--- a/lib/napa/output_formatters/pagination.rb
+++ b/lib/napa/output_formatters/pagination.rb
@@ -15,6 +15,7 @@ module Napa
         p[:per_page]      = @object.limit_value   if @object.respond_to?(:limit_value)
         p[:total_pages]   = @object.total_pages   if @object.respond_to?(:total_pages)
         p[:total_count]   = @object.total_count   if @object.respond_to?(:total_count)
+        p[:result_count]  = @object.total_count   if @object.respond_to?(:total_count)
       end
     end
 

--- a/lib/napa/version.rb
+++ b/lib/napa/version.rb
@@ -1,3 +1,3 @@
 module Napa
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/spec/output_formatters/pagination_spec.rb
+++ b/spec/output_formatters/pagination_spec.rb
@@ -18,6 +18,7 @@ describe Napa::Pagination do
       expect(data.to_h[:per_page]).to be(25)
       expect(data.to_h[:total_pages]).to be(10)
       expect(data.to_h[:total_count]).to be(248)
+      expect(data.to_h[:result_count]).to be(248)
     end
 
     it 'skips an attribute if the object does not respond to it' do
@@ -31,6 +32,7 @@ describe Napa::Pagination do
       expect(data.to_h[:per_page]).to be(25)
       expect(data.to_h[:total_pages]).to be_nil
       expect(data.to_h[:total_count]).to be_nil
+      expect(data.to_h[:result_count]).to be_nil
     end
   end
 end


### PR DESCRIPTION
Adding `result_count` for backward compatibility with one of our services. This key is expected by some of our clients. 

@sisk @jonhoman @darbyfrey 
@bellycard/platform 
